### PR TITLE
URI escape the resource when making REST requests

### DIFF
--- a/lib/wallix_rest_client.rb
+++ b/lib/wallix_rest_client.rb
@@ -76,7 +76,11 @@ module WallixRestClient
 
     # Run the HTTP request
     def run_request(path, resource, type, query_params = {}, post_params = {})
-      uri = URI::join(configuration.base_uri, '/api/', path, resource.to_s, build_query_params(query_params))
+      uri = URI::join(
+        configuration.base_uri, '/api/', path,
+        URI.encode_www_form_component(resource.to_s, enc=Encoding::UTF_8),
+        build_query_params(query_params)
+      )
 
       http = build_http(uri)
       request = build_request(type, uri)


### PR DESCRIPTION
Parameter *resource* in *run_request* comes from the user and may contain anything, ranging from slashes, backslashes, question marks and kinds of other characters likely to break the resulting URI because of how URI::join behaves.

I ran *rake spec* and at least these lines are covered. I don’t know how thoroughly we should test edge cases though.